### PR TITLE
Bug Fixes and add param to savedonor

### DIFF
--- a/src/DonorPerfect.php
+++ b/src/DonorPerfect.php
@@ -208,10 +208,12 @@ class DonorPerfect
         $paramString = '';
         $i = 0;
         foreach ($parameters as $param => $value) {
+            $original = $value;
             $value = trim($value);
 
             if (
-                is_numeric($value)
+                !is_object($original)
+                && is_numeric($value)
                 && strpos($value, 'e') === false
                 && strpos($value, '+') === false
             ) {

--- a/src/DonorPerfect.php
+++ b/src/DonorPerfect.php
@@ -629,11 +629,15 @@ class DonorPerfect
      */
     public function dp_savedonor($data)
     {
-        // The nomail parameter is a required field for dp_savedonor. Make sure it is
-        // set properly and default to N if missing or invalid to prevent error.
-        if (!isset($data['nomail']) || $data['nomail'] != 'Y') $data['nomail'] = 'N';
-        // receipt delivery defaults to L if unspecified, make it explicit
-        if (!isset($data['receipt_delivery'])) $data['receipt_delivery'] = 'L';
+        // nomail is required for dp_savedonor, ensure it is present and valid
+        if (!isset($data['nomail']) || $data['nomail'] != 'Y') {
+            $data['nomail'] = 'N';
+        }
+        // receipt_delivery defaults to L if unspecified, make it explicit
+        if (!isset($data['receipt_delivery'])) {
+            $data['receipt_delivery'] = 'L';
+        }
+
         return $this->call('dp_savedonor', static::prepareParams($data, [
             'donor_id'        => ['numeric'], // Enter 0 (zero) to create a new donor/constituent record or an existing donor_id. Please note: If you are updating an existing donor, all existing values for the fields specified below will be overwritten by the values you send with this API call.
             'first_name'      => ['string', 50], //

--- a/src/DonorPerfect.php
+++ b/src/DonorPerfect.php
@@ -792,7 +792,7 @@ class DonorPerfect
             'receipt_delivery_g'  => ['string', 1], // ‘E’ for email, ‘B’ for both email and letter, ‘L’ for letter, ‘N’ for do not acknowledge or NULL
             'contact_id'          => ['numeric'], // Or NULL
             'acknowledgepref'     => ['string', 3],
-            'currency'            => ['string', 3]
+            'currency'            => ['string', 3],
         ]));
     }
 

--- a/src/DonorPerfect.php
+++ b/src/DonorPerfect.php
@@ -272,9 +272,9 @@ class DonorPerfect
                 $output .= $sql[$i];
             }
         }
-        
+
         $params = [
-            'action' => $cleansql_new,
+            'action' => $output
         ];
 
         return $this->callInternal($params);

--- a/src/DonorPerfect.php
+++ b/src/DonorPerfect.php
@@ -121,8 +121,6 @@ class DonorPerfect
 
         // Validate the API call before making it
         $relativeUrl .= http_build_query($args, null, '&', PHP_QUERY_RFC3986);
-        // encode any + signs
-        $relativeUrl = str_replace('+', '%2B', $relativeUrl);
 
         if (strlen(static::$baseUrl . $relativeUrl) > 8000) {
             throw new Exception('The DonorPerfect API call exceeds the maximum length permitted (8000 characters)');

--- a/src/DonorPerfect.php
+++ b/src/DonorPerfect.php
@@ -224,6 +224,9 @@ class DonorPerfect
             } elseif (is_array($value)) {
                 $value = "N'" . implode($value, '|') . "'";
             } else {
+                // Ensure wrapped string values are still trimmed
+                $value = trim($value);
+            
                 // Ensure quotes are doubled for escaping purposes
                 // @see https://api.warrenbti.com/2020/08/03/apostrophes-in-peoples-names/
                 $value = str_replace(["'", '"', '%'], ["''", '', '%25'], $value);

--- a/src/DonorPerfect.php
+++ b/src/DonorPerfect.php
@@ -648,19 +648,11 @@ class DonorPerfect
     {
         // nomail is required for dp_savedonor, ensure it is present and valid
         if (!isset($data['nomail']) || $data['nomail'] != 'Y') {
-<<<<<<< HEAD
           $data['nomail'] = 'N';
         }
         // receipt delivery defaults to L if unspecified, make it explicit
         if (!isset($data['receipt_delivery'])) {
           $data['receipt_delivery'] = 'L';
-=======
-            $data['nomail'] = 'N';
-        }
-        // receipt_delivery defaults to L if unspecified, make it explicit
-        if (!isset($data['receipt_delivery'])) {
-            $data['receipt_delivery'] = 'L';
->>>>>>> dae202008870d4b375720b6245989f84943e22e6
         }
 
         return $this->call('dp_savedonor', static::prepareParams($data, [

--- a/src/DonorPerfect.php
+++ b/src/DonorPerfect.php
@@ -255,19 +255,24 @@ class DonorPerfect
      */
     public function callSql($sql)
     {
-        // Clean the sql of extra spaces and tabs
-        $cleansql = $sql;
-        $done = false;
-        do {
-          $cleansql_new = trim(str_ireplace(["\n", "\t", '  ', '  )'], [' ', '', ' ', ' )'], $cleansql));
-          if ($cleansql_new === $cleansql) {
-            $done = true;
-          }
-          else {
-            $cleansql = $cleansql_new;
-          }
-        } while (!$done);
+        // Remove all formatting whitespace while leaving whitespace that is part of value strings
+        $in_quote = false;
+        $output = '';
 
+        for ($i = 0; $i < strlen($sql); $i++) {
+            if ($sql[$i] == "'" || $sql[$i] == '"') {
+                $in_quote = !$in_quote;
+            }
+            if (($sql[$i] == ' ' || $sql[$i] == "\n" || $sql[$i] == "\r") && !$in_quote) {
+                if (empty($output) || substr($output, -1) == ' ') {
+                    continue;
+                }
+                $output .= ' ';
+            } else {
+                $output .= $sql[$i];
+            }
+        }
+        
         $params = [
             'action' => $cleansql_new,
         ];

--- a/src/DonorPerfect.php
+++ b/src/DonorPerfect.php
@@ -208,11 +208,12 @@ class DonorPerfect
         $paramString = '';
         $i = 0;
         foreach ($parameters as $param => $value) {
-            $original = $value;
-            $value = trim($value);
+            if (is_string($value)) {
+                $value = trim($value);
+            }
 
             if (
-                !is_object($original)
+                !is_object($value)
                 && is_numeric($value)
                 && strpos($value, 'e') === false
                 && strpos($value, '+') === false

--- a/src/DonorPerfect.php
+++ b/src/DonorPerfect.php
@@ -214,7 +214,6 @@ class DonorPerfect
                 is_numeric($value)
                 && strpos($value, 'e') === false
                 && strpos($value, '+') === false
-                && $param != 'CardExpirationDate'
             ) {
                 $value = $value;
             } elseif (is_bool($value)) {
@@ -315,7 +314,7 @@ class DonorPerfect
      * @param mixed $value  The value to prepare
      * @param int   $maxlen The maximum length of the string
      * @throws Exception if the provided value is longer than the max allowed length
-     * @return string
+     * @return object (Annonymous class that implements __toString and holds the string value)
      */
     public static function prepareString($value, int $maxlen = null)
     {
@@ -325,7 +324,20 @@ class DonorPerfect
             throw new Exception("$value is longer than the max allowed length of $maxlen");
         }
 
-        return $value;
+        // Returns as an anonymous class that implements __toString in order to ensure
+        // that numeric values that have been explicitly declared as strings are not
+        // converted to integers when processed in the call() method.
+        return new class($value) {
+            protected string $value;
+            public function __construct(string $value)
+            {
+                $this->value = $value;
+            }
+            public function __toString()
+            {
+                return $this->value;
+            }
+        };
     }
 
     /**


### PR DESCRIPTION
1) Fix: Don't allow + symbol in params as it generates an error.
2) Fix: + symbol resolves to a numeric but is not numeric (ex. in phone numbers). Treat anything with a + as a string so the + can be removed.
3) Fix: Card expiration date resolves to a numeric field (in vault) but the data field is not numeric.
4) Fix: nomail is a required field and generates an error if set to NULL. If unspecified, set it to N.
5) Add: receipt_delivery param to savedonor (not in the API documentation, but a legitimate parameter)